### PR TITLE
podmerge: don't delete student from the old pod

### DIFF
--- a/nma-cn-bot.py
+++ b/nma-cn-bot.py
@@ -1034,6 +1034,12 @@ class nmaClient(discord.Client):
                                 )
                                 totalCount += 1
                             except:
+                                await logChan.send(
+                                    embed=embedGen(
+                                        "WARNING!",
+                                        f"Could not add {user.name} to pod-{cmdMsg[2]}.",
+                                    )
+                                )
                                 continue
                     await message.channel.send(
                         embed=embedGen(

--- a/nma-dl-bot.py
+++ b/nma-dl-bot.py
@@ -1034,6 +1034,12 @@ class nmaClient(discord.Client):
                                 )
                                 totalCount += 1
                             except:
+                                await logChan.send(
+                                    embed=embedGen(
+                                        "WARNING!",
+                                        f"Could not add {user.name} to pod-{cmdMsg[2]}.",
+                                    )
+                                )
                                 continue
                     await message.channel.send(
                         embed=embedGen(


### PR DESCRIPTION
Assign students from the old pod to the new pod instead of moving them to the new pod:

```
# p1 = {s1, s2}, p2 = {s3}

--nma podmerge p1 p2

# before: p2 = {s1, s2, s3}
# after: p1 = {s1, s2}, p2 = {s1, s2, s3}
```